### PR TITLE
Added arg check for build script

### DIFF
--- a/build_images.sh
+++ b/build_images.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ $# -eq 0 ]; then
+    echo "Please provide a number as an argument to tag the images with. e.g. ./build_images.sh 4"
+    exit 1
+fi
+
 echo "Creating temp dir"
 mkdir temp && cd temp
 


### PR DESCRIPTION
So when you do `./build_images.sh`, it says:

```bash
$ ./build_images.sh
Please provide a number as an argument to tag the images with. e.g. ./build_images.sh 4
```

And then you correctly do:

```bash
$ ./build_images.sh 4
```